### PR TITLE
remove namespace from CRD

### DIFF
--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -36,7 +36,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kadalustorages.kadalu-operator.storage
-  namespace: kadalu
 spec:
   group: kadalu-operator.storage
   names:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->
CRDs which are namespace scoped should not have metadata.namespace defined. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition. 
In our particular case, this will prevent Flux to reconcile the kustomization:
```bash
timeout waiting for: [CustomResourceDefinition/kadalu/kadalustorages.kadalu-operator.storage status: 'Unknown']
```
**What this PR does / why we need it**:
It removes the namespace from the CRD as described in the [CRD definition](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition)

**Which issue(s) this PR fixes**:
Fixes: https://github.com/fluxcd/flux2/issues/2739

**Special notes for your reviewer**:


**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
